### PR TITLE
(FEAT)[KAN-34] Implement Authorization flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/nodemailer": "^6.4.17",
     "@types/redis": "^4.0.10",
     "bcrypt": "^6.0.0",
+    "express-rate-limit": "^8.1.0",
     "handlebars": "^4.7.8",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      express-rate-limit:
+        specifier: ^8.1.0
+        version: 8.1.0(express@5.1.0)
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -481,6 +484,12 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  express-rate-limit@8.1.0:
+    resolution: {integrity: sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -607,6 +616,10 @@ packages:
   install@0.13.0:
     resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
     engines: {node: '>= 0.10'}
+
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -1558,6 +1571,11 @@ snapshots:
 
   etag@1.8.1: {}
 
+  express-rate-limit@8.1.0(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+      ip-address: 10.0.1
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -1711,6 +1729,8 @@ snapshots:
   inherits@2.0.4: {}
 
   install@0.13.0: {}
+
+  ip-address@10.0.1: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/src/controller/authentication.ts
+++ b/src/controller/authentication.ts
@@ -1,0 +1,118 @@
+import { Request, Response } from 'express';
+import { authenticationService } from '../services/authentication';
+import { CustomAppError, TokenExpiredError } from '../middlewares/errorHandler';
+import { RoleType } from '../models/identity';
+
+export const login = async (req: Request, res: Response) => {
+    const { username, password } = req.body;
+    if (!username || !password || typeof username !== 'string' || typeof password !== 'string') {
+        res.status(400).json({ error: "Username and password are required and must be strings." });
+    }
+
+    try {
+        // Use await to get the resolved token
+        const result = await authenticationService.login({ emailOrusername: username, password });
+        if (typeof result === 'object' && result !== null && 'token' in result && 'user_id' in result) {
+            res.status(200).json(result);
+        } else if (typeof result === 'string') {
+            const response = { 
+                user_id: result,
+                useranme: username
+            }
+            
+            res.status(489).json(response)
+        }
+    } catch(error) {
+        if (error instanceof CustomAppError) {
+            res.status(error.statusCode).json({ message: error.message })
+        }
+    }
+}
+
+export const register = async (req: Request, res: Response) => {
+    const { username, email, password } = req.body;
+
+    if (!username || !email || !password || typeof username !== 'string' || typeof email !== 'string' || typeof password !== 'string') {
+        res.status(400).json({ error: "Username, email, and password are required and must be strings." });
+    }
+
+    const role = req.body.role || RoleType.USER;
+    const user = {
+        username,
+        email,
+        password,
+        role
+    };
+
+    try {
+        await authenticationService.register(user)
+        res.status(200).json({ message: "Account created successfully"})
+    } catch (error) {
+        if (error instanceof CustomAppError) {
+            res.status(error.statusCode).json({ message: error.message })
+        }
+    }
+}
+
+export const validateEmail = async (req: Request, res: Response) => {
+    const activationToken = req.query.activation_token as string;
+    const email = req.query.email as string;
+    const userId = req.query.id as string;
+
+    if (!activationToken || !email) {
+        res.status(400).send('Missing activation token or user ID.');
+    }
+
+    try {
+        const result = await authenticationService.validateEmail(activationToken, email, userId)
+        res.status(200).json(result)
+    } catch (error) {
+        if (error instanceof TokenExpiredError) {
+            res.status(error.statusCode).json( {message: error.message} )
+        }
+    }
+}
+
+export const validateOtp = async (req: Request, res: Response) => {
+    const otp = req.query.otp as string;
+    const email = req.query.username as string;
+    const userId = req.query.id as string;
+
+    if(!otp || !email || !userId) {
+        res.status(400).send('Missing otp or user ID or email');
+    }
+
+    try {
+        const result = await authenticationService.validateOTP(otp, email, userId)
+        res.status(200).json(result)
+    } catch (error) {
+        if (error instanceof TokenExpiredError) {
+            res.status(error.statusCode).json( {message: error.message} )
+        }
+    }
+}
+
+export const resendOtp = async (req: Request, res: Response) => {
+    const email = req.query.email as string;
+
+    if(!email) {
+        res.status(400).send('Missing email');
+    }
+
+    await authenticationService.resendOtp(email)
+
+    res.status(200).json({ message: 'OTP sent'})
+}
+
+export const resendAccountActivation = async (req: Request, res: Response) => {
+    const email = req.query.email as string;
+    const userId = req.query.id as string;
+
+    if (!email || !userId) {
+        res.status(400).send('Missing email or user ID')
+    }
+
+    await authenticationService.resendAccountActivation(userId, email)
+
+    res.status(200).json({ message: 'Account activation email sent'})
+}

--- a/src/controller/user.ts
+++ b/src/controller/user.ts
@@ -1,14 +1,13 @@
-// Routes for user management
 import { NextFunction, Request, Response } from 'express';
 import { userService } from '../services/user';
 
 export const getUserById = async (req: Request, res: Response, next: NextFunction) => {
-        const userId: string | undefined = req.params.id;
-        if (!userId) res.status(400).json
-        try {
-            const user = await userService.getUserById(userId);
-            if (user) res.json(user);
-        } catch (error){
-            next(error)
-        }
+    const userId: string | undefined = req.params.id;
+    if (!userId) res.status(400).json({ error: "User ID is required" });
+    try {
+        const user = await userService.getUserById(userId);
+        if (user) res.json(user);
+    } catch (error){
+        next(error)
     }
+}

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -62,9 +62,7 @@ export const userRepository = {
                 user.password,
                 user.role
             ];
-            console.log("Start create User")
             const result = await client.query(query, values);
-            console.log(result)
             const newUserId = result.rows[0].id;
             return newUserId;
         } catch (err) {

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import userRouter from "./public/user";
+import authenticationRouter from "./public/authentication";
 
 const publicRouter = Router();
 
-publicRouter.use('/', userRouter)
+publicRouter.use('/users', userRouter)
+publicRouter.use('/authentication', authenticationRouter)
 
 export default publicRouter;

--- a/src/routers/public/authentication.ts
+++ b/src/routers/public/authentication.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { login, register, resendAccountActivation, resendOtp, validateEmail, validateOtp } from "../../controller/authentication";
+import rateLimit from "express-rate-limit";
+
+const loginRateLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 5, // limit each IP to 5 requests per windowMs
+    message: "Too many login attempts from this IP, please try again after a minute."
+})
+
+const authenticationRouter = Router()
+
+authenticationRouter.get('/activate_email', validateEmail)
+authenticationRouter.get('/validate_otp', validateOtp)
+authenticationRouter.get('/resend_otp', resendOtp)
+authenticationRouter.get('/resend_account_activation', resendAccountActivation)
+
+authenticationRouter.post('/login', loginRateLimiter, login);
+authenticationRouter.post('/register', register)
+
+export default authenticationRouter;

--- a/src/routers/public/user.ts
+++ b/src/routers/public/user.ts
@@ -1,9 +1,8 @@
 import { Router } from "express";
 import { getUserById } from "../../controller/user";
 
-
 const userRouter = Router();
 
-userRouter.get('/users/:id', getUserById);
+userRouter.get('/:id', getUserById);
 
 export default userRouter;

--- a/src/services/authentication.ts
+++ b/src/services/authentication.ts
@@ -1,33 +1,100 @@
-import { CustomAppError, NotFoundError, UnauthorizedError } from "../middlewares/errorHandler";
-import { UserCredentials, userRepository } from "../repositories/user";
+import { redisService } from "../database/redis";
+import { JWTTokenResponse } from "../interfaces/jwt";
+import { ValidateResponse } from "../interfaces/security";
+import { LoginRequest, RegisterRequest, UserCredentials } from "../interfaces/user";
+import { AccountNotEnableError, ConflictError, NotFoundError, TokenExpiredError, UnauthorizedError } from "../middlewares/errorHandler";
+import { RoleType } from "../models/identity";
+import { tokenRepository } from "../repositories/token";
+import { userRepository } from "../repositories/user";
+import { emailService } from "./email";
 import { securityService } from "./security";
 
 export const authenticationService = {
-    async login(emailOrUsername: string, password: string): Promise<string | null> {
-        try {
-            const userCredentials: UserCredentials | null = await userRepository.getUserCredentialsByUsernameOrEmail(emailOrUsername);
-            if (!userCredentials) {
-                throw new NotFoundError("User not found");
-            }
-            if (await securityService.verifyPassword(password, userCredentials.password)) {
-                throw new UnauthorizedError("Invalid password")
-            }
+    async login(user: LoginRequest): Promise<JWTTokenResponse | string | null> {
+        const userCredentials: UserCredentials | null = await userRepository.getUserCredentialsByUsernameOrEmail(user.emailOrusername);
 
-            if (userCredentials.token === null) {
-                throw new NotFoundError("Token not found");
-            }
-
-            // Validate the token
-            return userCredentials.token;
-        } catch (error) {
-            console.error('Error in authenticationService.login:', error);
-            if (error instanceof CustomAppError) {
-                throw error; 
-            } else if (error instanceof Error) {
-                throw new CustomAppError(`Failed to retrieve user: ${error.message}`, 500);
-            } else {
-                throw new CustomAppError('An unknown error occurred in authentication service.', 500);
-            }
+        if (!userCredentials) {
+            throw new NotFoundError("User not found");
         }
+        
+        const isPasswordValid = await securityService.verifyPassword(user.password, userCredentials.password);
+        if (!isPasswordValid) {
+            throw new UnauthorizedError("Invalid password");
+        }
+
+        if (!userCredentials.is_enable) {
+            const activationToken = securityService.generateEmailActivationToken()
+            redisService.saveEmailActivationToken(activationToken, userCredentials.email)
+
+            emailService.sendActivateAccountEmail(userCredentials.email, activationToken, userCredentials.id)
+            throw new AccountNotEnableError("Account not enabled please check email")
+        }
+
+        // Check for an existing token
+        if (userCredentials.token === null || !securityService.isJWTTokenStillValid(userCredentials.token)) {
+            const otp = securityService.generateOTP()
+            redisService.saveOTP(otp, userCredentials.email)
+            emailService.sendOTPEmail(userCredentials.email, otp)
+            return userCredentials.id
+        }
+
+        return { 
+            user_id: userCredentials.id,
+            token: userCredentials.token
+        };
+    },
+
+    async register(user: RegisterRequest) {
+        const emailExists = await userRepository.checkIfEmailExists(user.email);
+        if (emailExists) {
+            throw new ConflictError("Email address is already in use.");
+        }
+        const newUser: RegisterRequest = {
+            ...user,
+            password: await securityService.hashPassword(user.password)
+        }
+
+        const userId = await userRepository.createUser(newUser);
+
+        const activationToken = securityService.generateEmailActivationToken()
+        redisService.saveEmailActivationToken(activationToken, user.email)
+
+        emailService.sendActivateAccountEmail(user.email, activationToken, userId)
+    },
+
+    async validateEmail(activationToken: string, email: string, userId: string): Promise<ValidateResponse | null> {
+        if (await securityService.checkEmailActivationCode(email, activationToken)) {
+            const userRole = await userRepository.getUserRole(userId) ?? RoleType.USER
+            const jwtToken = securityService.generateJWTToken(email, userRole)
+            await userRepository.enableAccountAndSetJWTToken(userId, jwtToken)
+            return { jwt_token: jwtToken }
+        }
+
+        throw new TokenExpiredError("Invalid or Expired activation code")
+    },
+
+    async validateOTP(otp: string, email: string, userId: string): Promise<ValidateResponse | null> {
+        if (await securityService.checkOTP(email, otp)) {
+            const userRole = await userRepository.getUserRole(userId) ?? RoleType.USER
+            const jwtToken = securityService.generateJWTToken(userId, userRole)
+            await tokenRepository.upsertTokenForUser(userId, jwtToken)
+            return { jwt_token: jwtToken }
+        }
+
+        throw new TokenExpiredError("Invalid or Expired activation code")
+    },
+
+    async resendOtp(email: string): Promise<void> {
+        const otp = securityService.generateOTP()
+        redisService.saveOTP(otp, email)
+        emailService.sendOTPEmail(email, otp)
+    },
+
+    async resendAccountActivation(userId: string, email: string): Promise<void> {
+        const activationToken = securityService.generateEmailActivationToken()
+        redisService.saveEmailActivationToken(activationToken, email)
+
+        emailService.sendActivateAccountEmail(email, activationToken, userId)
+        throw new AccountNotEnableError("Account not enabled please check email")
     }
 }

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -3,10 +3,8 @@ import { emailConfig } from "../configs/emailConfig";
 import handlebars from 'handlebars';
 import fs from 'fs';
 import path from 'path';
-
-interface EmailContext {
-    [key: string]: any;
-}
+import { EmailContext } from "../interfaces/email";
+import serverConfig from "../configs/serverConfig";
 
 class EmailService {
     private transporter: Transporter;
@@ -24,7 +22,9 @@ class EmailService {
         this.transporter.verify((error, success) => {
             if (error) {
                 console.error('Nodemailer configuration error:', error);
-            } else {
+            } 
+            
+            if (success) {
                 console.log('Nodemailer ready to send emails.');
             }
         });
@@ -36,7 +36,7 @@ class EmailService {
         return handlebars.compile(source);
     }
 
-    public async sendEmail(to: string, subject: string, templateName: string, context: EmailContext): Promise<void> {
+    public async sendEmail(email: string, subject: string, templateName: string, context: EmailContext): Promise<void> {
         try {
             const template = await this.compileTemplate(templateName);
 
@@ -50,7 +50,7 @@ class EmailService {
 
             const mailOptions = {
                 from: process.env.EMAIL_USER, // Sender address
-                to: to,                     // Recipient address
+                to: email,                     // Recipient address
                 subject: subject,           // Subject line
                 html: htmlContent,          // HTML body
                 // text: "Plain text version of the email (good for fallback)", // Optional: plain text version
@@ -63,6 +63,25 @@ class EmailService {
             console.error('Error sending email:', error);
             throw new Error('Failed to send email.'); // Re-throw to handle in calling function
         }
+    }
+
+    public async sendActivateAccountEmail(email: string, activationToken: string, userId: string) {
+        const activationLink = `${serverConfig.url}/api/public/authentication/activate_email?id=${userId}&activation_token=${activationToken}&email=${email}`;
+        this.sendEmail(
+            email, 
+            "Activate your account", 
+            "ActivateAccountMail", 
+            { "activation_link": activationLink }
+        )
+    }
+
+    public async sendOTPEmail(email: string, otp: string) {
+        this.sendEmail(
+            email,
+            "Your OTP",
+            "OTPMail",
+            { otp: otp }
+        )
     }
 }
 

--- a/src/services/security.ts
+++ b/src/services/security.ts
@@ -1,24 +1,14 @@
-import jwt, { NotBeforeError, TokenExpiredError } from 'jsonwebtoken';
+import jwt, { JsonWebTokenError, NotBeforeError, TokenExpiredError } from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 import { securityConfig } from '../configs/securityConfig';
-import { UnauthorizedError } from '../middlewares/errorHandler';
-
-interface securityService {
-    hashPassword(password: string): Promise<string>
-    verifyPassword(password: string, hashedPassword: string): Promise<boolean>
-    isJWTTokenStillValid(token: string): boolean
-    generateJWTToken(userId: string): string
-    decodeJWTToken(token: string): JWTPayload
-    getDeviceFingerprint(req: Request): string
-
-}
-
-interface JWTPayload {
-    userId: string 
-}
+import { JWTPayload } from '../interfaces/jwt';
+import { securityServiceInterface } from '../interfaces/services/security';
+import { redisService } from '../database/redis';
+import { RoleType } from '../models/identity';
 
 const SALT_ROUNDS = 10
-export const securityService: securityService = {
+export const securityService: securityServiceInterface = {
     async hashPassword(password: string): Promise<string> {
         try {
             // bcrypt.hash handles salt generation and iteration internally based on saltRounds
@@ -42,26 +32,20 @@ export const securityService: securityService = {
 
     isJWTTokenStillValid(token: string): boolean {
         try {
-            this.decodeJWTToken(token); 
+            this.decodeJWTToken(token);
             return true;
-        } catch (error) {
-            if (error instanceof TokenExpiredError) {
-                throw new UnauthorizedError("Token has expired")
-            }
-            if (error instanceof NotBeforeError) {
-                throw new UnauthorizedError("Token is not valid")
-            }
-        } finally {
+        } catch {
             return false;
         }
     },
 
-    generateJWTToken(userId: string): string {
-        const payload: JWTPayload = { userId };
+    generateJWTToken(userId: string, roleId: RoleType): string {
+        const payload: JWTPayload = {
+            payload: { userId, roleId }
+        };
         
         const token = jwt.sign(payload, securityConfig.jwtSecret, {
             expiresIn: securityConfig.expiresIn,
-            notBefore: Date.now(),
             subject: userId,
             algorithm: 'HS256',
         })
@@ -70,12 +54,63 @@ export const securityService: securityService = {
     },
 
     // will throw {JsonWebTokenError | TokenExpiredError | NotBeforeError} if faild to decode token
-    decodeJWTToken(token: string): JWTPayload {
-        const decoded = jwt.verify(token, securityConfig.jwtSecret) as JWTPayload;
+    decodeJWTToken(token: string): JWTPayload | null {
+        try {
+        const decoded = jwt.verify(token, securityConfig.jwtSecret, { algorithms: ['HS256'] }) as JWTPayload;
         return decoded;
+        } catch (err) {
+            if (err instanceof TokenExpiredError) {
+                console.error("JWT verification failed: TokenExpiredError ->", err.message);
+            } else if (err instanceof NotBeforeError) {
+                console.error("JWT verification failed: NotBeforeError ->", err.message);
+            } else if (err instanceof JsonWebTokenError) {
+                console.error("JWT verification failed: JsonWebTokenError ->", err.message);
+            } else {
+                console.error("JWT verification failed: Unknown error ->", err);
+            }
+            throw err; // rethrow so caller can still handle
+        }
     },
 
-    getDeviceFingerprint(req: Request): string {
-        return ""
+    generateEmailActivationToken(): string {
+        try {
+            // Generate a 16-byte buffer of cryptographically secure random data
+            const buffer = crypto.randomBytes(16)
+            // Convert the buffer to a hexadecimal string and return it
+            const token = buffer.toString('hex');
+            return token;
+        } catch (err) {
+            console.error("Failed to generate activation token:", err);
+            throw new Error("Token generation failed");
+        }
+    },
+
+    generateOTP(): string {
+        const otp = crypto.randomInt(100000, 1000000)
+        return otp.toString()
+    },
+
+    async checkEmailActivationCode(email: string, activationCode: string): Promise<boolean> {
+        try {
+            const cacheActivationCode = await redisService.getEmailActivationToken(email)
+            if(cacheActivationCode !== activationCode) {
+                return false
+            }
+            return true
+        } catch {
+            return false
+        }
+    },
+
+    async checkOTP(email: string, otp: string): Promise<boolean> {
+        try {
+            const cacheOtp = await redisService.getOTP(email)
+            if(cacheOtp !== otp) {
+                return false
+            }
+            return true
+        } catch {
+            return false
+        }
     }
 }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,6 +1,7 @@
 // Service for user management
+import { UserInfo } from "../interfaces/user";
 import { CustomAppError, NotFoundError } from "../middlewares/errorHandler";
-import { userRepository, UserInfo } from "../repositories/user";
+import { userRepository } from "../repositories/user";
 
 export const userService = {
     async getUserById(userId: string): Promise<UserInfo | null> {


### PR DESCRIPTION
# What's new
- Added Authorization flow api

## POST
### `/api/public/authentication/login`
```json
{
   "username": string (username or email),
   "password": string
}
```
`/api/public/authentication/register`
```json
{
   "username": string,
   "email": string,
   "password": string,
   ("role": number (role id, this will default to be regular user))
}
```

## GET
`/api/public/authentication/activate_email`
- all info in this will be send via email
```query
activation_toke: string
email: string
id: string
```
`/api/public/authentication/validate_otp`
```query
otp: string
email: string
id: string
```
`/api/public/authentication/resend_account_activation`
```query
email: string
id: string
```
`/api/public/authentication/resend_otp`
```query
email: string
id: string
```